### PR TITLE
⚰️ Add `lgtm` README badge, drop unused import

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ pip install relational-datasets
 
 [![PyPi Version](https://img.shields.io/pypi/v/relational-datasets)](https://pypi.org/project/relational-datasets/)
 [![License](https://img.shields.io/github/license/srlearn/relational-datasets)](https://github.com/srlearn/relational-datasets/blob/main/LICENSE)
+[![Total alerts](https://img.shields.io/lgtm/alerts/g/srlearn/relational-datasets.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/srlearn/relational-datasets/alerts/)
 [![Python Package Builds](https://github.com/srlearn/relational-datasets/actions/workflows/python-package.yml/badge.svg)](https://github.com/srlearn/relational-datasets/actions/workflows/python-package.yml)
 [![Documentation Deploy](https://github.com/srlearn/relational-datasets/actions/workflows/deploy-docs.yml/badge.svg)](https://github.com/srlearn/relational-datasets/actions/workflows/deploy-docs.yml)
 

--- a/relational_datasets/types.py
+++ b/relational_datasets/types.py
@@ -5,7 +5,6 @@
 Custom Types
 """
 
-from collections import namedtuple
 from typing import List, NamedTuple
 
 __all__ = ["RelationalDataset"]


### PR DESCRIPTION
Add `lgtm` README badge showing number of alerts
Drop `from collections import namedtuple` from `types.py` since it was replaced by `typing.NamedTuple`