### PR TITLE
✨ Add multiclass classification support

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,20 @@
 
 ## Beta
 
+### v0.2.2 - 2021-12-04
+
+Software Changes:
+
+- Add multiclass support to `convert.from_numpy`
+
+Documentation:
+
+- Add notebook with overview on converting multiclass vector datasets
+
+Testing:
+
+- Add tests for `convert.from_numpy`
+
 ### v0.2.1 - 2021-12-01
 
 Software Changes:

--- a/docs/notebooks/02_multiclass.ipynb
+++ b/docs/notebooks/02_multiclass.ipynb
@@ -1,0 +1,434 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Converting multiclass vector datasets\n",
+    "\n",
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/srlearn/relational-datasets/blob/main/docs/notebooks/02_multiclass.ipynb)\n",
+    "[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/srlearn/relational-datasets/HEAD?filepath=docs%2Fnotebooks%2F02_multiclass.ipynb)\n",
+    "\n",
+    "**Abstract**: This tutorial extends some ideas in the *Converting machine learning benchmark datasets* to demonstrate how multiclass datasets work.\n",
+    "\n",
+    "Examples in this notebook are provided as documentation, and are available under the terms of the Apache 2.0 License."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install relational-datasets"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Refresher on Binary Classification\n",
+    "\n",
+    "When `y` is a vector containing 0 and 1, then examples are automatically split into positive and negative examples:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['v4(id3).']"
+      ]
+     },
+     "execution_count": 1,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from relational_datasets.convert import from_numpy\n",
+    "import numpy as np\n",
+    "\n",
+    "binary_data, binary_modes = from_numpy(\n",
+    "    np.array([[0, 1, 1], [0, 1, 2], [1, 2, 2]]),\n",
+    "    np.array([0, 0, 1]),\n",
+    ")\n",
+    "\n",
+    "binary_data.pos"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['v4(id1).', 'v4(id2).']"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "binary_data.neg"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "When `y` is a vector containing *more* than 0 and 1, then we're in a multiclass setting."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['v4(id1,0).', 'v4(id2,1).', 'v4(id3,2).']"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "multiclass_data, multiclass_modes = from_numpy(\n",
+    "    np.array([[0, 1, 1], [0, 1, 2], [1, 2, 2]]),\n",
+    "    np.array([0, 1, 2]),\n",
+    ")\n",
+    "\n",
+    "multiclass_data.pos"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In this case, all of the examples are placed into the *positive examples*, and the *negative examples* are left empty. For classification, data should be further split into $K$ one-versus-rest datasets."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[]"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "multiclass_data.neg"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The modes should reflect this difference:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'v4(+id).'"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "binary_modes[-1]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'v4(+id,#classlabel).'"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "multiclass_modes[-1]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Worked example with scikit-learn's `load_iris`\n",
+    "\n",
+    "Here we: (**1**) load the data and class labels, (**2**) split into training and test sets, (**3**) bin the continuous features to discrete, and (**4**) convert to the relational format."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install scikit-learn"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sklearn.datasets import load_iris\n",
+    "from sklearn.model_selection import train_test_split\n",
+    "from sklearn.preprocessing import KBinsDiscretizer"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### (1) Load the data, target, and variable names\n",
+    "\n",
+    "Invoking `load_iris` returns a dictionary-like object with keys for `.data`, `.target`, `.feature_names`, and `.target_names`. We'll use these to pull out our `X` matrix, `y` array, and variable names."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,\n",
+       "       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,\n",
+       "       0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,\n",
+       "       1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,\n",
+       "       1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,\n",
+       "       2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,\n",
+       "       2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2])"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "iris = load_iris()\n",
+    "\n",
+    "X = iris.data\n",
+    "y = iris.target\n",
+    "variable_names = [name.replace(\"(cm)\", \"\").replace(\" \", \"\") for name in iris.feature_names] + [iris.target_names[1]]\n",
+    "\n",
+    "y"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['sepallength', 'sepalwidth', 'petallength', 'petalwidth', 'versicolor']"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "variable_names"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### (2) Split out training and test sets"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "X_train, X_test, y_train, y_test = train_test_split(X, y)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### (3) Discretize continuous features to discrete\n",
+    "\n",
+    "scikit-learn's `KBinsDiscretizer` will help us here, but we'll want an ordinal (0, 1, 2, 3, 4) encoding for our discrete features rather than the default one-hot encoding, and we need to ensure that the resulting matrices are converted back to integers."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "disc = KBinsDiscretizer(n_bins=5, encode=\"ordinal\")\n",
+    "\n",
+    "X_train = disc.fit_transform(X_train).astype(int)\n",
+    "X_test = disc.transform(X_test).astype(int)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['sepallength(+id,#varsepallength).',\n",
+       " 'sepalwidth(+id,#varsepalwidth).',\n",
+       " 'petallength(+id,#varpetallength).',\n",
+       " 'petalwidth(+id,#varpetalwidth).',\n",
+       " 'versicolor(+id,#classlabel).']"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "iris_train, iris_modes = from_numpy(X_train, y_train, names=variable_names)\n",
+    "\n",
+    "iris_modes"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### (4) Convert arrays to `RelationalDataset`\n",
+    "\n",
+    "Finally, let's convert our training and test folds into RelationalDatasets and modes:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "iris_test, _ = from_numpy(X_test, y_test, names=variable_names)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(112, 0, 448)"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "len(iris_train.pos), len(iris_train.neg), len(iris_train.facts)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(38, 0, 152)"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "len(iris_test.pos), len(iris_test.neg), len(iris_test.facts)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/relational_datasets/_version.py
+++ b/relational_datasets/_version.py
@@ -1,4 +1,4 @@
 # Copyright © 2021 Alexander L. Hayes
 # Apache 2.0 License
 
-__version__ = "v0.2.2-dev"
+__version__ = "v0.2.2"

--- a/relational_datasets/convert/tests/test_convert_numpy.py
+++ b/relational_datasets/convert/tests/test_convert_numpy.py
@@ -79,3 +79,38 @@ def test_convert_numpy_regression():
         "v3(+id,#varv3).",
         "v4(+id).",
     ]
+
+def test_convert_multiclass():
+    """Test converting a multiclass classification problem."""
+
+    X = numpy.array([[0, 1, 1], [1, 0, 2], [2, 2, 0], [1, 1, 1]])
+    y = numpy.array([0, 0, 1, 2])
+    data, modes = from_numpy(X, y)
+
+    assert data.pos == [
+        "v4(id1,0).",
+        "v4(id2,0).",
+        "v4(id3,1).",
+        "v4(id4,2).",
+    ]
+    assert data.neg == []
+    assert data.facts == [
+        "v1(id1,0).",
+        "v1(id2,1).",
+        "v1(id3,2).",
+        'v1(id4,1).',
+        "v2(id1,1).",
+        "v2(id2,0).",
+        "v2(id3,2).",
+        'v2(id4,1).',
+        "v3(id1,1).",
+        "v3(id2,2).",
+        "v3(id3,0).",
+        'v3(id4,1).'
+    ]
+    assert modes == [
+        "v1(+id,#varv1).",
+        "v2(+id,#varv2).",
+        "v3(+id,#varv3).",
+        "v4(+id,#classlabel).",
+    ]


### PR DESCRIPTION
Add methods to `convert_numpy` to support
setting up multiclass classification problems.

These add examples to `RelationalDataset.pos`,
leaving `.neg` empty. Assuming a `OneVsRest`
style implementation is added to `srlearn`
soon, splitting to pos/neg can be handled
elsewhere.