### PR TITLE
🐛 Append variable name to constant in `from_numpy`

### DIFF
--- a/relational_datasets/convert/convert_numpy.py
+++ b/relational_datasets/convert/convert_numpy.py
@@ -85,7 +85,7 @@ def from_numpy(X: np.ndarray, y: np.ndarray, names: Optional[List[str]] = None) 
 
     elif _task == "multiclass-classification":
         for i, row in enumerate(y, 1):
-            pos.append(f"{names[-1]}(id{i},{row}).")
+            pos.append(f"{names[-1]}(id{i},{names[-1]}_{row}).")
 
     else:
         # _get_task(y) == "regression"
@@ -94,7 +94,7 @@ def from_numpy(X: np.ndarray, y: np.ndarray, names: Optional[List[str]] = None) 
 
     for i, col in enumerate(X.T):
         var = names[i]
-        facts += [f"{var}(id{j},{row})." for j, row in enumerate(col, 1)]
+        facts += [f"{var}(id{j},{var}_{row})." for j, row in enumerate(col, 1)]
 
     modes = [f"{name}(+id,#var{name})." for name in names[:-1]]
     if _task == "multiclass-classification":

--- a/relational_datasets/convert/tests/test_convert_numpy.py
+++ b/relational_datasets/convert/tests/test_convert_numpy.py
@@ -17,27 +17,24 @@ def test_convert_numpy_classification():
     y = numpy.array([0, 0, 1, 1])
     data, modes = from_numpy(X, y)
 
-    assert data.pos == [
-        "v4(id3).",
-        "v4(id4)."
-    ]
+    assert data.pos == ["v4(id3).", "v4(id4)."]
     assert data.neg == [
         "v4(id1).",
         "v4(id2).",
     ]
     assert data.facts == [
-        "v1(id1,0).",
-        "v1(id2,1).",
-        "v1(id3,2).",
-        'v1(id4,1).',
-        "v2(id1,1).",
-        "v2(id2,0).",
-        "v2(id3,2).",
-        'v2(id4,1).',
-        "v3(id1,1).",
-        "v3(id2,2).",
-        "v3(id3,0).",
-        'v3(id4,1).'
+        "v1(id1,v1_0).",
+        "v1(id2,v1_1).",
+        "v1(id3,v1_2).",
+        "v1(id4,v1_1).",
+        "v2(id1,v2_1).",
+        "v2(id2,v2_0).",
+        "v2(id3,v2_2).",
+        "v2(id4,v2_1).",
+        "v3(id1,v3_1).",
+        "v3(id2,v3_2).",
+        "v3(id3,v3_0).",
+        "v3(id4,v3_1).",
     ]
     assert modes == [
         "v1(+id,#varv1).",
@@ -45,6 +42,7 @@ def test_convert_numpy_classification():
         "v3(+id,#varv3).",
         "v4(+id).",
     ]
+
 
 def test_convert_numpy_regression():
     """Test converting a regression problem."""
@@ -56,22 +54,22 @@ def test_convert_numpy_regression():
         "regressionExample(v4(id1),0.1).",
         "regressionExample(v4(id2),0.2).",
         "regressionExample(v4(id3),0.3).",
-        "regressionExample(v4(id4),0.4)."
+        "regressionExample(v4(id4),0.4).",
     ]
     assert data.neg == []
     assert data.facts == [
-        "v1(id1,0).",
-        "v1(id2,1).",
-        "v1(id3,2).",
-        'v1(id4,1).',
-        "v2(id1,1).",
-        "v2(id2,0).",
-        "v2(id3,2).",
-        'v2(id4,1).',
-        "v3(id1,1).",
-        "v3(id2,2).",
-        "v3(id3,0).",
-        'v3(id4,1).'
+        "v1(id1,v1_0).",
+        "v1(id2,v1_1).",
+        "v1(id3,v1_2).",
+        "v1(id4,v1_1).",
+        "v2(id1,v2_1).",
+        "v2(id2,v2_0).",
+        "v2(id3,v2_2).",
+        "v2(id4,v2_1).",
+        "v3(id1,v3_1).",
+        "v3(id2,v3_2).",
+        "v3(id3,v3_0).",
+        "v3(id4,v3_1).",
     ]
     assert modes == [
         "v1(+id,#varv1).",
@@ -79,6 +77,7 @@ def test_convert_numpy_regression():
         "v3(+id,#varv3).",
         "v4(+id).",
     ]
+
 
 def test_convert_multiclass():
     """Test converting a multiclass classification problem."""
@@ -88,25 +87,25 @@ def test_convert_multiclass():
     data, modes = from_numpy(X, y)
 
     assert data.pos == [
-        "v4(id1,0).",
-        "v4(id2,0).",
-        "v4(id3,1).",
-        "v4(id4,2).",
+        "v4(id1,v4_0).",
+        "v4(id2,v4_0).",
+        "v4(id3,v4_1).",
+        "v4(id4,v4_2).",
     ]
     assert data.neg == []
     assert data.facts == [
-        "v1(id1,0).",
-        "v1(id2,1).",
-        "v1(id3,2).",
-        'v1(id4,1).',
-        "v2(id1,1).",
-        "v2(id2,0).",
-        "v2(id3,2).",
-        'v2(id4,1).',
-        "v3(id1,1).",
-        "v3(id2,2).",
-        "v3(id3,0).",
-        'v3(id4,1).'
+        "v1(id1,v1_0).",
+        "v1(id2,v1_1).",
+        "v1(id3,v1_2).",
+        "v1(id4,v1_1).",
+        "v2(id1,v2_1).",
+        "v2(id2,v2_0).",
+        "v2(id3,v2_2).",
+        "v2(id4,v2_1).",
+        "v3(id1,v3_1).",
+        "v3(id2,v3_2).",
+        "v3(id3,v3_0).",
+        "v3(id4,v3_1).",
     ]
     assert modes == [
         "v1(+id,#varv1).",


### PR DESCRIPTION
For example: If "variable 1" takes value "0", then the created
fact will be:

```
v1(id1,v1_0).
```

This *should* make it more likely that the unique variable
names assumption is not violated.

See also
--------

- https://github.com/srlearn/SRLBoost/issues/42
- https://github.com/srlearn/datasets/issues/19