### PR TITLE
📝 Update notebooks to align with variable name changes

### DIFF
--- a/docs/notebooks/00_loading_and_fetching.ipynb
+++ b/docs/notebooks/00_loading_and_fetching.ipynb
@@ -40,7 +40,7 @@
     {
      "data": {
       "text/plain": [
-       "'/home/hayesall/relational_datasets/toy_cancer_v0.0.3.zip'"
+       "'/Users/hayesall/relational_datasets/toy_cancer_v0.0.5.zip'"
       ]
      },
      "execution_count": 1,
@@ -51,7 +51,7 @@
    "source": [
     "from relational_datasets import fetch\n",
     "\n",
-    "fetch('toy_cancer', 'v0.0.3')"
+    "fetch('toy_cancer', 'v0.0.5')"
    ]
   },
   {
@@ -91,7 +91,7 @@
    "source": [
     "from relational_datasets import load\n",
     "\n",
-    "train, test = load('toy_cancer', 'v0.0.3')\n",
+    "train, test = load('toy_cancer', 'v0.0.5')\n",
     "\n",
     "train.pos"
    ]
@@ -99,7 +99,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -113,7 +113,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.9"
+   "version": "3.8.13"
   }
  },
  "nbformat": 4,

--- a/docs/notebooks/01_converting_propositional_datasets.ipynb
+++ b/docs/notebooks/01_converting_propositional_datasets.ipynb
@@ -113,15 +113,15 @@
     {
      "data": {
       "text/plain": [
-       "['v1(id1,0).',\n",
-       " 'v1(id2,0).',\n",
-       " 'v1(id3,1).',\n",
-       " 'v2(id1,1).',\n",
-       " 'v2(id2,1).',\n",
-       " 'v2(id3,2).',\n",
-       " 'v3(id1,1).',\n",
-       " 'v3(id2,2).',\n",
-       " 'v3(id3,2).']"
+       "['v1(id1,v1_0).',\n",
+       " 'v1(id2,v1_0).',\n",
+       " 'v1(id3,v1_1).',\n",
+       " 'v2(id1,v2_1).',\n",
+       " 'v2(id2,v2_1).',\n",
+       " 'v2(id3,v2_2).',\n",
+       " 'v3(id1,v3_1).',\n",
+       " 'v3(id2,v3_2).',\n",
+       " 'v3(id3,v3_2).']"
       ]
      },
      "execution_count": 5,
@@ -244,15 +244,15 @@
     {
      "data": {
       "text/plain": [
-       "['v1(id1,0).',\n",
-       " 'v1(id2,0).',\n",
-       " 'v1(id3,1).',\n",
-       " 'v2(id1,1).',\n",
-       " 'v2(id2,1).',\n",
-       " 'v2(id3,2).',\n",
-       " 'v3(id1,1).',\n",
-       " 'v3(id2,2).',\n",
-       " 'v3(id3,2).']"
+       "['v1(id1,v1_0).',\n",
+       " 'v1(id2,v1_0).',\n",
+       " 'v1(id3,v1_1).',\n",
+       " 'v2(id1,v2_1).',\n",
+       " 'v2(id2,v2_1).',\n",
+       " 'v2(id3,v2_2).',\n",
+       " 'v3(id1,v3_1).',\n",
+       " 'v3(id2,v3_2).',\n",
+       " 'v3(id3,v3_2).']"
       ]
      },
      "execution_count": 10,
@@ -341,21 +341,21 @@
     {
      "data": {
       "text/plain": [
-       "['age(id1,1).',\n",
-       " 'age(id2,1).',\n",
-       " 'age(id3,0).',\n",
-       " 'age(id4,1).',\n",
-       " 'age(id5,0).',\n",
-       " 'bmi(id1,1).',\n",
-       " 'bmi(id2,1).',\n",
-       " 'bmi(id3,1).',\n",
-       " 'bmi(id4,1).',\n",
-       " 'bmi(id5,1).',\n",
-       " 'cac(id1,2).',\n",
-       " 'cac(id2,0).',\n",
-       " 'cac(id3,0).',\n",
-       " 'cac(id4,1).',\n",
-       " 'cac(id5,1).']"
+       "['age(id1,age_1).',\n",
+       " 'age(id2,age_1).',\n",
+       " 'age(id3,age_0).',\n",
+       " 'age(id4,age_1).',\n",
+       " 'age(id5,age_0).',\n",
+       " 'bmi(id1,bmi_1).',\n",
+       " 'bmi(id2,bmi_1).',\n",
+       " 'bmi(id3,bmi_1).',\n",
+       " 'bmi(id4,bmi_1).',\n",
+       " 'bmi(id5,bmi_1).',\n",
+       " 'cac(id1,cac_2).',\n",
+       " 'cac(id2,cac_0).',\n",
+       " 'cac(id3,cac_0).',\n",
+       " 'cac(id4,cac_1).',\n",
+       " 'cac(id5,cac_1).']"
       ]
      },
      "execution_count": 14,
@@ -585,7 +585,9 @@
    "source": [
     "### (3) Discretize continuous features to discrete\n",
     "\n",
-    "scikit-learn's [`KBinsDiscretizer`](https://scikit-learn.org/stable/modules/generated/sklearn.preprocessing.KBinsDiscretizer.html) will help us here, but we'll want an ordinal (0, 1, 2, 3, 4) encoding for our discrete features rather than the default one-hot encoding, and we need to ensure that the resulting matrices are converted back to integers."
+    "scikit-learn's [`KBinsDiscretizer`](https://scikit-learn.org/stable/modules/generated/sklearn.preprocessing.KBinsDiscretizer.html) will help us here, but we'll want an ordinal (0, 1, 2, 3, 4) encoding for our discrete features rather than the default one-hot encoding, and we need to ensure that the resulting matrices are converted back to integers.\n",
+    "\n",
+    "<div class=\"alert alert-block alert-info\"> <b>NOTE</b> Notice that we call <code>.astype(int)</code> on the outputs of the discretizer. Usually scikit-learn returns floats in these cases.</div>"
    ]
   },
   {
@@ -596,12 +598,12 @@
     {
      "data": {
       "text/plain": [
-       "array([[4, 4, 4, ..., 4, 2, 1],\n",
-       "       [2, 1, 2, ..., 0, 1, 2],\n",
-       "       [4, 3, 4, ..., 4, 2, 3],\n",
+       "array([[2, 2, 2, ..., 1, 1, 0],\n",
+       "       [1, 0, 1, ..., 1, 0, 2],\n",
+       "       [1, 2, 1, ..., 2, 3, 1],\n",
        "       ...,\n",
-       "       [0, 0, 0, ..., 2, 0, 0],\n",
-       "       [1, 3, 1, ..., 1, 1, 3],\n",
+       "       [4, 4, 4, ..., 4, 2, 3],\n",
+       "       [4, 3, 4, ..., 4, 3, 3],\n",
        "       [1, 0, 1, ..., 1, 0, 1]])"
       ]
      },
@@ -612,10 +614,8 @@
    ],
    "source": [
     "disc = KBinsDiscretizer(n_bins=5, encode=\"ordinal\")\n",
-    "X_train = disc.fit_transform(X_train)\n",
-    "X_test = disc.transform(X_test)\n",
-    "X_train = X_train.astype(int)\n",
-    "X_test = X_test.astype(int)\n",
+    "X_train = disc.fit_transform(X_train).astype(int)\n",
+    "X_test = disc.transform(X_test).astype(int)\n",
     "\n",
     "X_train"
    ]
@@ -685,7 +685,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -699,7 +699,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.9"
+   "version": "3.8.13"
   }
  },
  "nbformat": 4,

--- a/docs/notebooks/02_multiclass.ipynb
+++ b/docs/notebooks/02_multiclass.ipynb
@@ -95,7 +95,7 @@
     {
      "data": {
       "text/plain": [
-       "['v4(id1,0).', 'v4(id2,1).', 'v4(id3,2).']"
+       "['v4(id1,v4_0).', 'v4(id2,v4_1).', 'v4(id3,v4_2).']"
       ]
      },
      "execution_count": 3,
@@ -391,7 +391,7 @@
    "cell_type": "code",
    "execution_count": 15,
    "metadata": {
-    "scrolled": false
+    "scrolled": true
    },
    "outputs": [
     {
@@ -412,7 +412,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -426,7 +426,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.9"
+   "version": "3.8.13"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Basically, this re-runs the three documentation notebooks to reflect
the changes introduced in #25

This also adds a note regarding the `.astype(int)` calls
in `01_converting_propositional_datasets.ipynb`