### PR TITLE
✨ Dataset loading recommendations

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -30,6 +30,8 @@ markdown_extensions:
       permalink: true
   - admonition
   - pymdownx.superfences
+  - pymdownx.tabbed:
+      alternate_style: true
   - pymdownx.snippets
   - pymdownx.tasklist
 


### PR DESCRIPTION
Add a feature to the `build_docs.py` script to insert content tabs recommending how to use the Python/Julia loaders with the latest version for each dataset:

![Preview of new page, showing the california_housing dataset title with two tabs beneath it. The left tab reads Python and the right tab reads Julia. Currently the Python tab is highlighted and the code beneath it says: from relational_datasets import load; load("california_housing", "v0.0.6")](https://user-images.githubusercontent.com/11916674/199800536-90da854b-a9f5-4ec4-b431-bb326fba990e.png)
