### PR TITLE
🔧 Set `pythonpublish.yml` to use `pypi-publish`

### DIFF
--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -18,10 +18,10 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install setuptools wheel twine
-    - name: Build and publish
-      env:
-        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+    - name: Build
       run: |
         python setup.py sdist bdist_wheel
-        twine upload dist/*
+    - name: Publish
+      uses: pypa/gh-action-pypi-publish@v1.5.1
+      with:
+        password: ${{ secrets.PYPI_API_TOKEN }}\


### PR DESCRIPTION
PyPi will deprecate using usernames and passwords with 2FA soon.

This replaces the "Build and publish" step with a `pypa/gh-action-pypi-publish@v1.5.1` action using the newly-generated `PYPI_API_TOKEN`.